### PR TITLE
Git-hook to enforce good coding practices

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -73,8 +73,11 @@ fi
 # if there are unstaged changes abort commit
 if ! git diff --quiet
 then
-	echo "${RED}error:$RST there are unstaged changes"
-	echo "aborting commit."
+	cat << EOF
+${RED}error:$RST there are unstaged files
+  (use "git restore <file>..." to discard changes in working directory)
+  (use "git stash" to put the changes away for later application)
+EOF
 	exit 1
 fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,134 @@
+#!/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments. The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+if git rev-parse --verify HEAD >/dev/null 2>&1
+then
+	against=HEAD
+else
+	# Initial commit: diff against an empty tree object
+	against=$(git hash-object -t tree /dev/null)
+fi
+
+# If you want to allow non-ASCII filenames set this variable to true.
+allownonascii=$(git config --type=bool hooks.allownonascii)
+
+# Cross platform projects tend to avoid non-ASCII filenames; prevent
+# them from being added to the repository. We exploit the fact that the
+# printable range starts at the space character and ends with tilde.
+if [ "$allownonascii" != "true" ] &&
+	# Note that the use of brackets around a tr range is ok here, (it's
+	# even required, for portability to Solaris 10's /usr/bin/tr), since
+	# the square bracket bytes happen to fall in the designated range.
+	test $(git diff-index --cached --name-only --diff-filter=A -z $against |
+	  LC_ALL=C tr -d '[ -~]\0' | wc -c) != 0
+then
+	cat <<EOF
+Error: Attempt to add a non-ASCII file name.
+
+This can cause problems if you want to work with people on other platforms.
+
+To be portable it is advisable to rename the file.
+
+If you know what you are doing you can disable this check using:
+
+  git config hooks.allownonascii true
+EOF
+	exit 1
+fi
+
+# If there are whitespace errors, print the offending file names and fail.
+out=$(git diff-index --check --cached $against --)
+
+if [ $? -ne 0 ]
+then
+	echo "$out"
+	exit 1
+fi
+
+# orpheus's code goes here
+# not the best code ik but hey it gets the job done
+
+
+RST="$(tput sgr0)"
+RED="$(tput setaf 1)"
+GREEN="$(tput setaf 2)"
+CYAN="$(tput setaf 6)"
+
+prettier="./node_modules/.bin/prettier"
+eslint="./node_modules/.bin/eslint"
+
+# if nothing is staged exit with success
+# it could be a commit with --allow-empty
+if git diff --staged --quiet
+then
+	exit 0
+fi
+
+# if there are unstaged changes abort commit
+if ! git diff --quiet
+then
+	echo "${RED}error:$RST there are unstaged changes"
+	echo "aborting commit."
+	exit 1
+fi
+
+# get all staged files, (except deleted files,
+# files whose mode bits are changed, and others...)
+files=$(git diff --staged --name-only --diff-filter="ACMR")
+
+# exit early if theres no such staged changes
+if [ -z "$files" ]
+then
+	exit 0
+fi
+
+# run prettier on all staged files
+if [ ! -x $prettier ]
+then
+	echo "${RED}error:$RST prettier is not installed"
+	echo "aborting commit."
+	exit 1
+fi
+
+echo "running prettier on staged files 🧙"
+# --write --list-different --ignore-unknown
+files=$(echo "$files" | sed 's| |\\ |g')
+out=$(echo "$files" | xargs $prettier -wlu)
+
+if [ "$out" ]
+then
+	echo "$out" | sed 's| |\\ |g' | xargs git add -v |
+		sed "s|^add '\\(.*\\)'|$GREEN - $RST\1|"
+fi
+
+echo "all files are looking pretty ✅"
+
+# run eslint on all staged files
+if [ ! -x $eslint ]
+then
+	echo "${RED}error:$RST eslint is not installed"
+	echo "aborting commit."
+	exit 1
+fi
+
+echo "eslint is checking all staged files..."
+out=$(echo "$files" | xargs -r $eslint --color --no-warn-ignored)
+
+if [ $? -eq 0 ]
+then
+	echo "all checks passed ✅"
+	exit 0
+fi
+
+echo "$out" | head -n -1 |
+	sed "\$s|.*(\(.*\) error, \(.*\) warnings).*|$CYAN\1 error \2 warnings$RST|"
+
+echo "fix linting errors and try again"
+echo "aborting commit."
+exit 1


### PR DESCRIPTION
Heres a little pre-commit hook I created over the past few days to ensure good coding practices among the participants. It's a patch work really, and could use some serious improvements but for now should get the job done. It executes prettier and eslint before every commit, and mostly aborts on errors.